### PR TITLE
Change default behaviour on pressing enter while presented Yes or No choice.

### DIFF
--- a/protonup/api.py
+++ b/protonup/api.py
@@ -121,7 +121,7 @@ def get_proton(version=None, yes=True, dl_only=False, output=None):
         print(f"Ready to download Proton-{data['version']}",
               f"\nSize      : {round(data['size']/MIB, 2)} MiB",
               f"\nPublished : {data['date']}")
-        if not input("Continue? (Y/N): ") in ['y', 'Y']:
+        if not input("Continue? (Y/n): ") in ['y', 'Y', '']:
             return
 
     # Prepare Destination
@@ -163,7 +163,7 @@ def remove_proton(version=None, yes=True):
     """Uninstall existing proton installation"""
     target = install_directory() + "Proton-" + version
     if os.path.exists(target):
-        if yes or input(f'Are you sure? (Y/N) ') in ['y', 'Y']:
+        if yes or input(f'Are you sure? (Y/n) ') in ['y', 'Y', '']:
             shutil.rmtree(install_directory() + 'Proton-' + version)
         return True
     return False


### PR DESCRIPTION
It bugged me for quite some time that yes/no confirmation when downloading and removing versions is not in line with how rest of the cli toolset works. I see that there's a certain syntax to show default option while presented Y/N choice, and it looks like this:

- ```Y/n``` means Yes is default if you just pressed enter and no only if you type N or n and press enter

- ```y/N``` means the same thing but in reverse, with No being the default. 

I changed protonup confirmations to be the former. I think this little QoL change can improve the tool a bit.