### PR TITLE
Adding an option to delete all older versions of proton after installing a new one

### DIFF
--- a/protonup/api.py
+++ b/protonup/api.py
@@ -162,7 +162,7 @@ def get_proton(version=None, yes=True, output=None, dl_only=False):
                     if input(f'Are you sure you want to delete ALL previous versions? (y/N) ') in ['Y', 'y']:
                         for i in versions_to_delete:
                             print('Deleting', "protonGE-" + i)
-                            remove_proton(version=i[7:])
+                            remove_proton(version=i)
         open(checksum_dir, 'w').write(download_checksum)
     elif not yes:
         print('[INFO] Dowloaded to: ' + destination)

--- a/protonup/api.py
+++ b/protonup/api.py
@@ -112,10 +112,10 @@ def get_proton(version=None, yes=True, output=None, dl_only=False):
             if local_checksum in source_checksum:
                 if not yes:
                     print(f"[INFO] Proton-{data['version']} already installed")
-                    print("[INFO] No updates found")
+                    print("[INFO] No hotfix found")
                 return
             elif not yes:
-                print("[INFO] Update available!")
+                print("[INFO] Hotfix available")
         else:
             if not yes:
                 print(f"[INFO] Proton-{data['version']} already installed")

--- a/protonup/api.py
+++ b/protonup/api.py
@@ -112,10 +112,10 @@ def get_proton(version=None, yes=True, output=None, dl_only=False):
             if local_checksum in source_checksum:
                 if not yes:
                     print(f"[INFO] Proton-{data['version']} already installed")
-                    print("[INFO] No hotfix found")
+                    print("[INFO] No updates found")
                 return
             elif not yes:
-                print("[INFO] Hotfix available")
+                print("[INFO] Update available!")
         else:
             if not yes:
                 print(f"[INFO] Proton-{data['version']} already installed")

--- a/protonup/api.py
+++ b/protonup/api.py
@@ -161,7 +161,7 @@ def get_proton(version=None, yes=True, output=None, dl_only=False):
                 if input(f'Would you like to delete {len(versions_to_delete)} previous version(s) of protonGE? (y/N) ') in ['Y', 'y']:
                     if input(f'Are you sure you want to delete ALL previous versions? (y/N) ') in ['Y', 'y']:
                         for i in versions_to_delete:
-                            print('Deleting', "protonGE-" + i)
+                            print('Deleting', i)
                             remove_proton(version=i)
         open(checksum_dir, 'w').write(download_checksum)
     elif not yes:


### PR DESCRIPTION
after installation of a new version user will be prompted:

```Would you like to delete N previous version(s) of protonGE? (y/N) ```

With N being a number of previous versions installed. If user just taps enter or writes N it will skip this portion of code, but if user opts into by typing Y it will ask again as a confirmation and then wipe all protonGE versions user had before. I personally find it useful as it will enable easier way to de-clutter.

In other small changes, output of `def installed_versions():` is now sorted latest to oldest version.