### PR TITLE
Remove argparse

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ license_files =
 packages = find:
 install_requires = 
 	requests
-	argparse
 	configparser
 python_requires = >3.6
 


### PR DESCRIPTION
`argparse` is a Python standard module. 