### PR TITLE
List available install directories

### DIFF
--- a/protonup/api.py
+++ b/protonup/api.py
@@ -6,7 +6,7 @@ import tarfile
 import requests
 from .utilities import download, sha512sum, readable_size
 from .constants import CONFIG_FILE, PROTONGE_URL
-from .constants import TEMP_DIR, DEFAULT_INSTALL_DIR
+from .constants import TEMP_DIR, DEFAULT_INSTALL_DIR, POSSIBLE_INSTALL_LOCATIONS
 
 
 def fetch_data(tag):
@@ -40,6 +40,19 @@ def fetch_releases(count=100):
     for release in requests.get(PROTONGE_URL + "?per_page=" + str(count)).json():
         tags.append(release['tag_name'])
     return tags
+
+
+def available_install_directories():
+    """
+    List available install directories
+    Return Type: str[]
+    """
+    available_dirs = []
+    for loc in POSSIBLE_INSTALL_LOCATIONS:
+        install_dir = os.path.expanduser(loc['install_dir'])
+        if os.path.exists(install_dir):
+            available_dirs.append(install_dir)
+    return available_dirs
 
 
 def install_directory(target=None):

--- a/protonup/cli.py
+++ b/protonup/cli.py
@@ -1,6 +1,6 @@
 """ProtonUp CLI"""
 import argparse
-from .api import install_directory, installed_versions
+from .api import install_directory, installed_versions, available_install_directories
 from .api import get_proton, remove_proton, fetch_releases
 from .utilities import folder_size, readable_size
 
@@ -16,6 +16,7 @@ def parse_arguments():
     parser.add_argument('-o', '--output', type=str, default=None, metavar='DIR',
                         help='set download directory')
     parser.add_argument('-d', '--dir', type=str, default=None, help='set installation directory')
+    parser.add_argument('--dirs', action='store_true', help='list available install directories')
     parser.add_argument('-y', '--yes', action='store_true', help='disable prompts and logs')
     parser.add_argument('--download', action='store_true', help='download only')
     parser.add_argument('--releases', action='store_true', help='list avaiable versions')
@@ -42,6 +43,10 @@ def main():
         _install_directory = install_directory()
         for item in installed_versions():
             print(f"{item} - {readable_size(folder_size(_install_directory + item))}")
+
+    if args.dirs:
+        for item in available_install_directories():
+            print(item)
 
     if args.releases:
         for tag in fetch_releases():

--- a/protonup/constants.py
+++ b/protonup/constants.py
@@ -2,6 +2,10 @@
 import os
 CONFIG_FILE = os.path.expanduser('~/.config/protonup/config.ini')
 DEFAULT_INSTALL_DIR = os.path.expanduser('~/.steam/root/compatibilitytools.d/')
+POSSIBLE_INSTALL_LOCATIONS = [
+    {'install_dir': '~/.steam/root/compatibilitytools.d/', 'display_name': 'Steam'},
+    {'install_dir': '~/.var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d/', 'display_name': 'Steam (Flatpak)'}
+]
 TEMP_DIR = '/tmp/protonup/'
 PROTONGE_URL = 'https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases'
 BUFFER_SIZE = 65536  # Work with 64 kb chunks


### PR DESCRIPTION
Adds the parameter `--dirs` to list all available install directories. Currently supports default Steam installation and Flatpak.
Cloud be extended to support other launchers like Lutris as well.